### PR TITLE
✨ feat: SVG wavy filter for organic orb edges (#5)

### DIFF
--- a/packages/core/src/components/wavy-filter.test.tsx
+++ b/packages/core/src/components/wavy-filter.test.tsx
@@ -1,0 +1,106 @@
+import { describe, expect, it } from 'bun:test';
+import { renderToString } from 'react-dom/server';
+import { Orb } from './orb';
+import { OrbScene } from './orb-scene';
+
+describe('WavyFilter', () => {
+  it('renders SVG filter when wavy is true', () => {
+    const html = renderToString(
+      <OrbScene>
+        <Orb color="#FF0000" wavy />
+      </OrbScene>,
+    );
+    expect(html).toContain('feTurbulence');
+    expect(html).toContain('feDisplacementMap');
+    expect(html).toContain('orbkit-wavy-');
+  });
+
+  it('does not render SVG filter when wavy is false', () => {
+    const html = renderToString(
+      <OrbScene>
+        <Orb color="#FF0000" wavy={false} />
+      </OrbScene>,
+    );
+    expect(html).not.toContain('feTurbulence');
+    expect(html).not.toContain('feDisplacementMap');
+  });
+
+  it('does not render SVG filter when wavy is omitted', () => {
+    const html = renderToString(
+      <OrbScene>
+        <Orb color="#FF0000" />
+      </OrbScene>,
+    );
+    expect(html).not.toContain('feTurbulence');
+  });
+
+  it('applies wavy config scale to displacement', () => {
+    const html = renderToString(
+      <OrbScene>
+        <Orb color="#FF0000" wavy={{ scale: 50 }} />
+      </OrbScene>,
+    );
+    // scale=50 → displacement scale attribute should be 50
+    expect(html).toContain('scale="50"');
+  });
+
+  it('applies wavy config speed to animation duration', () => {
+    const html = renderToString(
+      <OrbScene>
+        <Orb color="#FF0000" wavy={{ speed: 2 }} />
+      </OrbScene>,
+    );
+    // speed=2 → duration = 8/2 = 4s
+    expect(html).toContain('dur="4s"');
+  });
+
+  it('applies wavy config intensity to octaves', () => {
+    const html = renderToString(
+      <OrbScene>
+        <Orb color="#FF0000" wavy={{ intensity: 5 }} />
+      </OrbScene>,
+    );
+    expect(html).toContain('numOctaves="5"');
+  });
+
+  it('clamps octaves between 1 and 6', () => {
+    const htmlHigh = renderToString(
+      <OrbScene>
+        <Orb color="#FF0000" wavy={{ intensity: 10 }} />
+      </OrbScene>,
+    );
+    expect(htmlHigh).toContain('numOctaves="6"');
+
+    const htmlLow = renderToString(
+      <OrbScene>
+        <Orb color="#FF0000" wavy={{ intensity: 0 }} />
+      </OrbScene>,
+    );
+    expect(htmlLow).toContain('numOctaves="1"');
+  });
+
+  it('generates unique filter IDs per orb', () => {
+    const html = renderToString(
+      <OrbScene>
+        <Orb color="#FF0000" wavy />
+        <Orb color="#00FF00" wavy />
+      </OrbScene>,
+    );
+    // Extract all orbkit-wavy-* filter IDs
+    const ids = html.match(/orbkit-wavy-[^"]+/g) ?? [];
+    const uniqueIds = new Set(ids);
+    // Should have at least 2 unique IDs (one per wavy orb)
+    expect(uniqueIds.size).toBeGreaterThanOrEqual(2);
+  });
+
+  it('combines wavy filter with blur in filter CSS', () => {
+    const html = renderToString(
+      <OrbScene>
+        <Orb color="#FF0000" wavy blur={50} />
+      </OrbScene>,
+    );
+    // Should have both url() reference and blur()
+    expect(html).toContain('url(#orbkit-wavy-');
+    expect(html).toContain('blur(50px)');
+  });
+});

--- a/packages/core/src/components/wavy-filter.tsx
+++ b/packages/core/src/components/wavy-filter.tsx
@@ -1,0 +1,61 @@
+import type { JSX } from 'react';
+import type { WavyConfig } from '../types';
+
+interface WavyFilterProps {
+  /** Unique filter ID for this orb */
+  filterId: string;
+  /** Wavy configuration */
+  config: WavyConfig;
+  /** Seed for deterministic noise variation */
+  seed: number;
+}
+
+/**
+ * WavyFilter — Inline SVG filter that applies organic edge distortion to an orb.
+ *
+ * Uses feTurbulence (Perlin noise) + feDisplacementMap to warp the orb's edges.
+ * Animation is handled via SVG <animate> — declarative, no JS, GPU-accelerated.
+ */
+export function WavyFilter({ filterId, config, seed }: WavyFilterProps): JSX.Element {
+  const scale = config.scale ?? 30;
+  const speed = config.speed ?? 1;
+  const octaves = Math.min(Math.max(Math.round(config.intensity ?? 3), 1), 6);
+
+  const baseFrequency = 0.01 + scale * 0.0005;
+  const safeSpeed = speed > 0 ? speed : 1;
+  const duration = 8 / safeSpeed;
+
+  return (
+    <svg
+      style={{ position: 'absolute', width: 0, height: 0 }}
+      aria-hidden="true"
+      className="orbkit-wavy-svg"
+    >
+      <defs>
+        <filter id={filterId}>
+          <feTurbulence
+            type="fractalNoise"
+            baseFrequency={baseFrequency}
+            numOctaves={octaves}
+            seed={seed}
+            result="noise"
+          >
+            <animate
+              attributeName="baseFrequency"
+              values={`${baseFrequency};${baseFrequency * 1.5};${baseFrequency}`}
+              dur={`${duration}s`}
+              repeatCount="indefinite"
+            />
+          </feTurbulence>
+          <feDisplacementMap
+            in="SourceGraphic"
+            in2="noise"
+            scale={scale}
+            xChannelSelector="R"
+            yChannelSelector="G"
+          />
+        </filter>
+      </defs>
+    </svg>
+  );
+}


### PR DESCRIPTION
## Summary

- **WavyFilter component** — Inline SVG `<feTurbulence>` + `<feDisplacementMap>` filter that gives orbs organic, fluid edges
- **SVG `<animate>` animation** — Declarative, no JS, GPU-accelerated baseFrequency animation
- **WavyConfig support** — `scale` (displacement amount), `speed` (animation speed), `intensity` (octaves 1-6, clamped)
- **Wired into Orb** — `<Orb wavy />` or `<Orb wavy={{ scale: 50, speed: 2 }} />` renders the filter and combines it with blur
- **SSR-safe unique IDs** — Uses React `useId()` for filter IDs that work in both SSR and client

### New files
- `components/wavy-filter.tsx` — SVG filter component
- `components/wavy-filter.test.tsx` — 9 tests

### Modified files
- `components/orb.tsx` — Renders WavyFilter when wavy is truthy, combines filter CSS

## Test plan
- [x] 50 tests pass (`bun test`) — 0 failures
- [x] TypeScript strict mode passes
- [x] Biome lint clean
- [ ] CodeRabbit review

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a "wavy" visual effect for Orb components with configurable scale, speed, and intensity parameters.
  * Wavy effect integrates seamlessly with blur styling for enhanced visual distortion.

* **Tests**
  * Added comprehensive test coverage for wavy effect behavior and configuration mappings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->